### PR TITLE
PHPUnit to Pest Converter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
-        "brianium/paratest": "^7.5",
         "laravel/framework": "^11.41",
         "laravel/horizon": "^5.22",
         "laravel/sanctum": "^4.0",
@@ -25,8 +24,9 @@
         "fakerphp/faker": "^1.23",
         "laravel/sail": "^1.26",
         "mockery/mockery": "^1.6",
-        "nunomaduro/collision": "^8.0",
-        "phpunit/phpunit": "^11.0.1"
+        "nunomaduro/collision": "^7.0",
+        "pestphp/pest": "^2.2",
+        "pestphp/pest-plugin-laravel": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Feature/AdminTest.php
+++ b/tests/Feature/AdminTest.php
@@ -1,110 +1,95 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Models\User;
 use App\Models\Webhook;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Livewire;
-use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-final class AdminTest extends TestCase
-{
-    use RefreshDatabase;
+uses(TestCase::class);
+uses(RefreshDatabase::class);
 
-    #[Test]
-    public function non_users_cant_see_the_homepage_dashboard(): void
-    {
-        $user = User::factory()->create();
-        $hook1 = Webhook::factory()->create();
-        $hook2 = Webhook::factory()->create();
+test('non users cant see the homepage dashboard', function () {
+    $user = User::factory()->create();
+    $hook1 = Webhook::factory()->create();
+    $hook2 = Webhook::factory()->create();
 
-        $response = $this->get(route('dashboard'));
+    $response = $this->get(route('dashboard'));
 
-        $response->assertRedirect(route('auth.login'));
-    }
+    $response->assertRedirect(route('auth.login'));
+});
 
-    #[Test]
-    public function users_can_see_see_the_homepage_dashboard(): void
-    {
-        $user = User::factory()->create();
-        $hook1 = Webhook::factory()->create();
-        $hook2 = Webhook::factory()->create();
+test('users can see see the homepage dashboard', function () {
+    $user = User::factory()->create();
+    $hook1 = Webhook::factory()->create();
+    $hook2 = Webhook::factory()->create();
 
-        $response = $this->actingAs($user)->get(route('dashboard'));
+    $response = $this->actingAs($user)->get(route('dashboard'));
 
-        $response->assertOk();
-        $response->assertSee('QR to Webhook');
-        $response->assertSeeLivewire('webhook-editor');
-        $response->assertSee($hook1->url);
-        $response->assertSee($hook2->url);
-    }
+    $response->assertOk();
+    $response->assertSee('QR to Webhook');
+    $response->assertSeeLivewire('webhook-editor');
+    $response->assertSee($hook1->url);
+    $response->assertSee($hook2->url);
+});
 
-    #[Test]
-    public function users_can_add_a_new_webhook(): void
-    {
-        $user = User::factory()->create();
-        $hook1 = Webhook::factory()->create();
-        $hook2 = Webhook::factory()->create();
+test('users can add a new webhook', function () {
+    $user = User::factory()->create();
+    $hook1 = Webhook::factory()->create();
+    $hook2 = Webhook::factory()->create();
 
-        Livewire::actingAs($user)->test('webhook-editor')
-            ->assertSee($hook1->url)
-            ->assertSee($hook2->url)
-            ->set('url', 'https://example.com/new-hook')
-            ->set('name', 'New Hook')
-            ->call('addWebhook')
-            ->assertSee($hook1->url)
-            ->assertSee($hook2->url)
-            ->assertSee('https://example.com/new-hook');
+    Livewire::actingAs($user)->test('webhook-editor')
+        ->assertSee($hook1->url)
+        ->assertSee($hook2->url)
+        ->set('url', 'https://example.com/new-hook')
+        ->set('name', 'New Hook')
+        ->call('addWebhook')
+        ->assertSee($hook1->url)
+        ->assertSee($hook2->url)
+        ->assertSee('https://example.com/new-hook');
 
-        $this->assertDatabaseHas('webhooks', [
-            'url' => 'https://example.com/new-hook',
-            'name' => 'New Hook',
-            'is_default' => false,
-        ]);
-    }
+    $this->assertDatabaseHas('webhooks', [
+        'url' => 'https://example.com/new-hook',
+        'name' => 'New Hook',
+        'is_default' => false,
+    ]);
+});
 
-    #[Test]
-    public function users_can_delete_an_existing_webhook(): void
-    {
-        $user = User::factory()->create();
-        $hook1 = Webhook::factory()->create();
-        $hook2 = Webhook::factory()->create();
-        $hook3 = Webhook::factory()->create();
+test('users can delete an existing webhook', function () {
+    $user = User::factory()->create();
+    $hook1 = Webhook::factory()->create();
+    $hook2 = Webhook::factory()->create();
+    $hook3 = Webhook::factory()->create();
 
-        Livewire::actingAs($user)->test('webhook-editor')
-            ->assertSee($hook1->url)
-            ->assertSee($hook2->url)
-            ->assertSee($hook3->url)
-            ->call('deleteWebhook', $hook2->id)
-            ->assertSee($hook1->url)
-            ->assertDontSee($hook2->url)
-            ->assertSee($hook3->url);
+    Livewire::actingAs($user)->test('webhook-editor')
+        ->assertSee($hook1->url)
+        ->assertSee($hook2->url)
+        ->assertSee($hook3->url)
+        ->call('deleteWebhook', $hook2->id)
+        ->assertSee($hook1->url)
+        ->assertDontSee($hook2->url)
+        ->assertSee($hook3->url);
 
-        $this->assertDatabaseMissing('webhooks', [
-            'id' => $hook2->id,
-        ]);
-    }
+    $this->assertDatabaseMissing('webhooks', [
+        'id' => $hook2->id,
+    ]);
+});
 
-    #[Test]
-    public function users_can_create_a_new_callable_url_to_hit_a_specific_webhook(): void
-    {
-        $hook = Webhook::factory()->create(['url' => 'https://example.com/new-hook', 'shortcode' => 'abc123']);
-        $user = User::factory()->create();
+test('users can create a new callable url to hit a specific webhook', function () {
+    $hook = Webhook::factory()->create(['url' => 'https://example.com/new-hook', 'shortcode' => 'abc123']);
+    $user = User::factory()->create();
 
-        Livewire::actingAs($user)->test('webhook-editor')
-            ->assertSee($hook->url)
-            ->assertDontSee('Text of message to send')
-            ->set('createUrlShortcode', 'abc123')
-            ->assertSee('Text of message to send')
-            ->set('newMessage', 'Hello World')
-            ->assertSee(route('api.help', [
-                'c' => 'abc123',
-                'etext' => '', // etext is encrypted so value will be random(ish) - just check it's in the query string
-            ]))
-            ->assertDontSee('&form=1')
-            ->set('newForm', 1)
-            ->assertSee('&form=1');
-    }
-}
+    Livewire::actingAs($user)->test('webhook-editor')
+        ->assertSee($hook->url)
+        ->assertDontSee('Text of message to send')
+        ->set('createUrlShortcode', 'abc123')
+        ->assertSee('Text of message to send')
+        ->set('newMessage', 'Hello World')
+        ->assertSee(route('api.help', [
+            'c' => 'abc123',
+            'etext' => '', // etext is encrypted so value will be random(ish) - just check it's in the query string
+        ]))
+        ->assertDontSee('&form=1')
+        ->set('newForm', 1)
+        ->assertSee('&form=1');
+});

--- a/tests/Feature/AdminTest.php
+++ b/tests/Feature/AdminTest.php
@@ -6,8 +6,6 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Livewire;
 use Tests\TestCase;
 
-uses(TestCase::class);
-uses(RefreshDatabase::class);
 
 test('non users cant see the homepage dashboard', function () {
     $user = User::factory()->create();

--- a/tests/Feature/AdminTest.php
+++ b/tests/Feature/AdminTest.php
@@ -2,10 +2,7 @@
 
 use App\Models\User;
 use App\Models\Webhook;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Livewire;
-use Tests\TestCase;
-
 
 test('non users cant see the homepage dashboard', function () {
     $user = User::factory()->create();

--- a/tests/Feature/ApiTest.php
+++ b/tests/Feature/ApiTest.php
@@ -9,8 +9,6 @@ use Ohffs\Ldap\LdapUser;
 use Ohffs\MSTeamsAlerts\Jobs\SendToMSTeamsChannelJob;
 use Tests\TestCase;
 
-uses(TestCase::class);
-uses(RefreshDatabase::class);
 
 test('an incoming request with base64 encoded text is resent as an ms teams webhook post', function () {
     Bus::fake();

--- a/tests/Feature/ApiTest.php
+++ b/tests/Feature/ApiTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Models\Webhook;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Bus;
@@ -9,161 +7,143 @@ use Ohffs\Ldap\FakeLdapConnection;
 use Ohffs\Ldap\LdapConnectionInterface;
 use Ohffs\Ldap\LdapUser;
 use Ohffs\MSTeamsAlerts\Jobs\SendToMSTeamsChannelJob;
-use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-final class ApiTest extends TestCase
+uses(TestCase::class);
+uses(RefreshDatabase::class);
+
+test('an incoming request with base64 encoded text is resent as an ms teams webhook post', function () {
+    Bus::fake();
+    $base64Text = base64_encode('test base64');
+    $webhook = Webhook::factory()->create(['url' => 'https://example.com/webhook/1234']);
+
+    $response = $this->get('/api/help?btext='.$base64Text.'&c='.$webhook->shortcode);
+
+    $response->assertRedirect(route('message').'?message='.base64_encode('Notification sent.'));
+    Bus::assertDispatched(SendToMSTeamsChannelJob::class, function ($job) use ($webhook) {
+        return $job->webhookUrl === $webhook->url && $job->text === 'test base64';
+    });
+});
+
+test('an incoming request with encrypted text is resent as an ms teams webhook post', function () {
+    Bus::fake();
+    $encryptedText = encrypt('test encrypted');
+    $webhook = Webhook::factory()->create(['url' => 'https://example.com/webhook/1234']);
+
+    $response = $this->get('/api/help?etext='.$encryptedText.'&c='.$webhook->shortcode);
+
+    $response->assertRedirect(route('message').'?message='.base64_encode('Notification sent.'));
+    Bus::assertDispatched(SendToMSTeamsChannelJob::class, function ($job) use ($webhook) {
+        return $job->webhookUrl === $webhook->url && $job->text === 'test encrypted';
+    });
+});
+
+test('an incoming request is resent to the default ms teams webhook if a specific one isnt specified in the query params', function () {
+    Bus::fake();
+    $webhook1 = Webhook::factory()->create(['url' => 'https://example.com/webhook/1234', 'is_default' => false]);
+    $webhook2 = Webhook::factory()->create(['url' => 'https://example.com/webhook/5678', 'is_default' => true]);
+
+    $response = $this->get('/api/help?btext='.base64_encode('test'));
+
+    $response->assertRedirect(route('message').'?message='.base64_encode('Notification sent.'));
+    Bus::assertDispatched(SendToMSTeamsChannelJob::class, function ($job) use ($webhook2) {
+        return $job->webhookUrl === $webhook2->url && $job->text === 'test';
+    });
+});
+
+test('a webhook can direct the user to a form for entering their details', function () {
+    Bus::fake();
+    $this->freezeTime();
+    $webhook = Webhook::factory()->create([
+        'url' => 'https://example.com/webhook/1234',
+    ]);
+
+    $response = $this->get('/api/help?form=1&btext='.base64_encode('test').'&c='.$webhook->shortcode);
+
+    $response->assertRedirect(route('form').'?btext='.urlencode(base64_encode('test')).'&c='.$webhook->shortcode);
+});
+
+test('submitting the form with valid details redirects to the webhook endpoint', function () {
+    Bus::fake();
+    $this->freezeTime();
+    fakeLdapConnection();
+    \Ldap::shouldReceive('authenticate')->with('validuser', 'validpassword')->andReturn(true);
+    \Ldap::shouldReceive('findUser')->with('validuser')->andReturn(new LdapUser([
+        [
+            'uid' => ['test1x'],
+            'mail' => ['testy@example.com'],
+            'sn' => ['mctesty'],
+            'givenname' => ['testy'],
+            'telephonenumber' => ['12345'],
+        ],
+    ]));
+    $webhook = Webhook::factory()->create([
+        'url' => 'https://example.com/webhook/1234',
+    ]);
+
+    $response = $this->post(route('form.submit', [
+        'username' => 'validuser',
+        'password' => 'validpassword',
+        'message' => 'test message',
+        'c' => $webhook->shortcode,
+    ]));
+
+    $response->assertRedirectQueryParamNotNull('etext');
+    $response->assertRedirectContains(route('api.help', [
+        'c' => $webhook->shortcode,
+        'etext' => '', // Note: as the text is encrypted it changes randomly every run, so just checking the param is in the query string
+    ]));
+});
+
+test('incoming webhooks update the timestamp on the record and update the stats', function () {
+    Bus::fake();
+    $this->freezeTime();
+    $webhook = Webhook::factory()->create(['url' => 'https://example.com/webhook/1234', 'updated_at' => now()->subDays(3), 'called_count' => 0]);
+
+    $this->assertEquals(0, $webhook->fresh()->called_count);
+
+    $response = $this->get('/api/help?btext='.base64_encode('test').'&c='.$webhook->shortcode);
+
+    $response->assertRedirect(route('message').'?message='.base64_encode('Notification sent.'));
+    Bus::assertDispatched(SendToMSTeamsChannelJob::class, function ($job) use ($webhook) {
+        return $job->webhookUrl === $webhook->url && $job->text === 'test';
+    });
+    $this->assertEquals(now()->format('Y-m-d'), $webhook->fresh()->updated_at->format('Y-m-d'));
+    $this->assertEquals(1, $webhook->fresh()->called_count);
+
+    $response = $this->get('/api/help?btext='.base64_encode('test').'&c='.$webhook->shortcode);
+
+    $response->assertRedirect(route('message').'?message='.base64_encode('Notification sent.'));
+    Bus::assertDispatched(SendToMSTeamsChannelJob::class, function ($job) use ($webhook) {
+        return $job->webhookUrl === $webhook->url && $job->text === 'test';
+    });
+    $this->assertEquals(now()->format('Y-m-d'), $webhook->fresh()->updated_at->format('Y-m-d'));
+    $this->assertEquals(2, $webhook->fresh()->called_count);
+});
+
+test('if the querystring is missing text we return an error', function () {
+    Bus::fake();
+
+    $response = $this->get('/api/help?sdfsdfsfd');
+
+    $response->assertRedirect(route('message').'?message='.urlencode(base64_encode('No message specified - no notification sent.')));
+    Bus::assertNotDispatched(SendToMSTeamsChannelJob::class);
+});
+
+test('if the querystring has an invalid webhook code we return an error', function () {
+    Bus::fake();
+
+    $response = $this->get('/api/help?text=sdfsdfsfd?c=blah');
+
+    $response->assertRedirect(route('message').'?message='.urlencode(base64_encode('Invalid channel - no notification sent.')));
+    Bus::assertNotDispatched(SendToMSTeamsChannelJob::class);
+});
+
+// Helpers
+function fakeLdapConnection()
 {
-    use RefreshDatabase;
-
-    #[Test]
-    public function an_incoming_request_with_base64_encoded_text_is_resent_as_an_ms_teams_webhook_post(): void
-    {
-        Bus::fake();
-        $base64Text = base64_encode('test base64');
-        $webhook = Webhook::factory()->create(['url' => 'https://example.com/webhook/1234']);
-
-        $response = $this->get('/api/help?btext='.$base64Text.'&c='.$webhook->shortcode);
-
-        $response->assertRedirect(route('message').'?message='.base64_encode('Notification sent.'));
-        Bus::assertDispatched(SendToMSTeamsChannelJob::class, function ($job) use ($webhook) {
-            return $job->webhookUrl === $webhook->url && $job->text === 'test base64';
-        });
-    }
-
-    #[Test]
-    public function an_incoming_request_with_encrypted_text_is_resent_as_an_ms_teams_webhook_post(): void
-    {
-        Bus::fake();
-        $encryptedText = encrypt('test encrypted');
-        $webhook = Webhook::factory()->create(['url' => 'https://example.com/webhook/1234']);
-
-        $response = $this->get('/api/help?etext='.$encryptedText.'&c='.$webhook->shortcode);
-
-        $response->assertRedirect(route('message').'?message='.base64_encode('Notification sent.'));
-        Bus::assertDispatched(SendToMSTeamsChannelJob::class, function ($job) use ($webhook) {
-            return $job->webhookUrl === $webhook->url && $job->text === 'test encrypted';
-        });
-    }
-
-    #[Test]
-    public function an_incoming_request_is_resent_to_the_default_ms_teams_webhook_if_a_specific_one_isnt_specified_in_the_query_params(): void
-    {
-        Bus::fake();
-        $webhook1 = Webhook::factory()->create(['url' => 'https://example.com/webhook/1234', 'is_default' => false]);
-        $webhook2 = Webhook::factory()->create(['url' => 'https://example.com/webhook/5678', 'is_default' => true]);
-
-        $response = $this->get('/api/help?btext='.base64_encode('test'));
-
-        $response->assertRedirect(route('message').'?message='.base64_encode('Notification sent.'));
-        Bus::assertDispatched(SendToMSTeamsChannelJob::class, function ($job) use ($webhook2) {
-            return $job->webhookUrl === $webhook2->url && $job->text === 'test';
-        });
-    }
-
-    #[Test]
-    public function a_webhook_can_direct_the_user_to_a_form_for_entering_their_details(): void
-    {
-        Bus::fake();
-        $this->freezeTime();
-        $webhook = Webhook::factory()->create([
-            'url' => 'https://example.com/webhook/1234',
-        ]);
-
-        $response = $this->get('/api/help?form=1&btext='.base64_encode('test').'&c='.$webhook->shortcode);
-
-        $response->assertRedirect(route('form').'?btext='.urlencode(base64_encode('test')).'&c='.$webhook->shortcode);
-    }
-
-    #[Test]
-    public function submitting_the_form_with_valid_details_redirects_to_the_webhook_endpoint(): void
-    {
-        Bus::fake();
-        $this->freezeTime();
-        $this->fakeLdapConnection();
-        \Ldap::shouldReceive('authenticate')->with('validuser', 'validpassword')->andReturn(true);
-        \Ldap::shouldReceive('findUser')->with('validuser')->andReturn(new LdapUser([
-            [
-                'uid' => ['test1x'],
-                'mail' => ['testy@example.com'],
-                'sn' => ['mctesty'],
-                'givenname' => ['testy'],
-                'telephonenumber' => ['12345'],
-            ],
-        ]));
-        $webhook = Webhook::factory()->create([
-            'url' => 'https://example.com/webhook/1234',
-        ]);
-
-        $response = $this->post(route('form.submit', [
-            'username' => 'validuser',
-            'password' => 'validpassword',
-            'message' => 'test message',
-            'c' => $webhook->shortcode,
-        ]));
-
-        $response->assertRedirectQueryParamNotNull('etext');
-        $response->assertRedirectContains(route('api.help', [
-            'c' => $webhook->shortcode,
-            'etext' => '', // Note: as the text is encrypted it changes randomly every run, so just checking the param is in the query string
-        ]));
-    }
-
-    #[Test]
-    public function incoming_webhooks_update_the_timestamp_on_the_record_and_update_the_stats(): void
-    {
-        Bus::fake();
-        $this->freezeTime();
-        $webhook = Webhook::factory()->create(['url' => 'https://example.com/webhook/1234', 'updated_at' => now()->subDays(3), 'called_count' => 0]);
-
-        $this->assertEquals(0, $webhook->fresh()->called_count);
-
-        $response = $this->get('/api/help?btext='.base64_encode('test').'&c='.$webhook->shortcode);
-
-        $response->assertRedirect(route('message').'?message='.base64_encode('Notification sent.'));
-        Bus::assertDispatched(SendToMSTeamsChannelJob::class, function ($job) use ($webhook) {
-            return $job->webhookUrl === $webhook->url && $job->text === 'test';
-        });
-        $this->assertEquals(now()->format('Y-m-d'), $webhook->fresh()->updated_at->format('Y-m-d'));
-        $this->assertEquals(1, $webhook->fresh()->called_count);
-
-        $response = $this->get('/api/help?btext='.base64_encode('test').'&c='.$webhook->shortcode);
-
-        $response->assertRedirect(route('message').'?message='.base64_encode('Notification sent.'));
-        Bus::assertDispatched(SendToMSTeamsChannelJob::class, function ($job) use ($webhook) {
-            return $job->webhookUrl === $webhook->url && $job->text === 'test';
-        });
-        $this->assertEquals(now()->format('Y-m-d'), $webhook->fresh()->updated_at->format('Y-m-d'));
-        $this->assertEquals(2, $webhook->fresh()->called_count);
-    }
-
-    #[Test]
-    public function if_the_querystring_is_missing_text_we_return_an_error(): void
-    {
-        Bus::fake();
-
-        $response = $this->get('/api/help?sdfsdfsfd');
-
-        $response->assertRedirect(route('message').'?message='.urlencode(base64_encode('No message specified - no notification sent.')));
-        Bus::assertNotDispatched(SendToMSTeamsChannelJob::class);
-    }
-
-    #[Test]
-    public function if_the_querystring_has_an_invalid_webhook_code_we_return_an_error(): void
-    {
-        Bus::fake();
-
-        $response = $this->get('/api/help?text=sdfsdfsfd?c=blah');
-
-        $response->assertRedirect(route('message').'?message='.urlencode(base64_encode('Invalid channel - no notification sent.')));
-        Bus::assertNotDispatched(SendToMSTeamsChannelJob::class);
-    }
-
-    private function fakeLdapConnection()
-    {
-        $this->instance(
-            LdapConnectionInterface::class,
-            new FakeLdapConnection('up', 'whatever')
-        );
-    }
+    test()->instance(
+        LdapConnectionInterface::class,
+        new FakeLdapConnection('up', 'whatever')
+    );
 }

--- a/tests/Feature/ApiTest.php
+++ b/tests/Feature/ApiTest.php
@@ -100,7 +100,7 @@ test('incoming webhooks update the timestamp on the record and update the stats'
     $this->freezeTime();
     $webhook = Webhook::factory()->create(['url' => 'https://example.com/webhook/1234', 'updated_at' => now()->subDays(3), 'called_count' => 0]);
 
-    $this->assertEquals(0, $webhook->fresh()->called_count);
+    expect($webhook->fresh()->called_count)->toEqual(0);
 
     $response = $this->get('/api/help?btext='.base64_encode('test').'&c='.$webhook->shortcode);
 
@@ -108,8 +108,8 @@ test('incoming webhooks update the timestamp on the record and update the stats'
     Bus::assertDispatched(SendToMSTeamsChannelJob::class, function ($job) use ($webhook) {
         return $job->webhookUrl === $webhook->url && $job->text === 'test';
     });
-    $this->assertEquals(now()->format('Y-m-d'), $webhook->fresh()->updated_at->format('Y-m-d'));
-    $this->assertEquals(1, $webhook->fresh()->called_count);
+    expect($webhook->fresh()->updated_at->format('Y-m-d'))->toEqual(now()->format('Y-m-d'));
+    expect($webhook->fresh()->called_count)->toEqual(1);
 
     $response = $this->get('/api/help?btext='.base64_encode('test').'&c='.$webhook->shortcode);
 
@@ -117,8 +117,8 @@ test('incoming webhooks update the timestamp on the record and update the stats'
     Bus::assertDispatched(SendToMSTeamsChannelJob::class, function ($job) use ($webhook) {
         return $job->webhookUrl === $webhook->url && $job->text === 'test';
     });
-    $this->assertEquals(now()->format('Y-m-d'), $webhook->fresh()->updated_at->format('Y-m-d'));
-    $this->assertEquals(2, $webhook->fresh()->called_count);
+    expect($webhook->fresh()->updated_at->format('Y-m-d'))->toEqual(now()->format('Y-m-d'));
+    expect($webhook->fresh()->called_count)->toEqual(2);
 });
 
 test('if the querystring is missing text we return an error', function () {

--- a/tests/Feature/ApiTest.php
+++ b/tests/Feature/ApiTest.php
@@ -1,14 +1,11 @@
 <?php
 
 use App\Models\Webhook;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Bus;
 use Ohffs\Ldap\FakeLdapConnection;
 use Ohffs\Ldap\LdapConnectionInterface;
 use Ohffs\Ldap\LdapUser;
 use Ohffs\MSTeamsAlerts\Jobs\SendToMSTeamsChannelJob;
-use Tests\TestCase;
-
 
 test('an incoming request with base64 encoded text is resent as an ms teams webhook post', function () {
     Bus::fake();

--- a/tests/Feature/CliTest.php
+++ b/tests/Feature/CliTest.php
@@ -1,9 +1,6 @@
 <?php
 
 use App\Models\Webhook;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
-
 
 test('there is an artisan command to make a new webhook', function () {
     $this->artisan('webhook:create', [

--- a/tests/Feature/CliTest.php
+++ b/tests/Feature/CliTest.php
@@ -13,12 +13,12 @@ test('there is an artisan command to make a new webhook', function () {
         'url' => 'https://example.com/webhook/1234',
     ])->assertExitCode(0);
 
-    $this->assertEquals(1, Webhook::count());
+    expect(Webhook::count())->toEqual(1);
     tap(Webhook::first(), function ($hook) {
-        $this->assertEquals('Test Webhook', $hook->name);
-        $this->assertEquals('https://example.com/webhook/1234', $hook->url);
+        expect($hook->name)->toEqual('Test Webhook');
+        expect($hook->url)->toEqual('https://example.com/webhook/1234');
         $this->assertNotNull($hook->shortcode);
-        $this->assertFalse($hook->is_default);
+        expect($hook->is_default)->toBeFalse();
     });
 });
 
@@ -31,14 +31,14 @@ test('we can optionally pass a flag to make the new webhook the default', functi
         'default' => 'true',
     ])->assertExitCode(0);
 
-    $this->assertEquals(2, Webhook::count());
+    expect(Webhook::count())->toEqual(2);
     tap(Webhook::where('name', 'Test Webhook')->first(), function ($hook) {
-        $this->assertEquals('Test Webhook', $hook->name);
-        $this->assertEquals('https://example.com/webhook/1234', $hook->url);
+        expect($hook->name)->toEqual('Test Webhook');
+        expect($hook->url)->toEqual('https://example.com/webhook/1234');
         $this->assertNotNull($hook->shortcode);
-        $this->assertTrue($hook->is_default);
+        expect($hook->is_default)->toBeTrue();
     });
-    $this->assertFalse($existingDefault->fresh()->is_default);
+    expect($existingDefault->fresh()->is_default)->toBeFalse();
 });
 
 test('if we dont pass options we are asked for input', function () {
@@ -47,12 +47,12 @@ test('if we dont pass options we are asked for input', function () {
         ->expectsQuestion('URL?', 'https://example.com/webhook/1234')
         ->assertExitCode(0);
 
-    $this->assertEquals(1, Webhook::count());
+    expect(Webhook::count())->toEqual(1);
     tap(Webhook::where('name', 'Test Webhook')->first(), function ($hook) {
-        $this->assertEquals('Test Webhook', $hook->name);
-        $this->assertEquals('https://example.com/webhook/1234', $hook->url);
+        expect($hook->name)->toEqual('Test Webhook');
+        expect($hook->url)->toEqual('https://example.com/webhook/1234');
         $this->assertNotNull($hook->shortcode);
-        $this->assertFalse($hook->is_default);
+        expect($hook->is_default)->toBeFalse();
     });
 });
 
@@ -111,9 +111,9 @@ test('there is an artisan command to set the default webhook', function () {
         'id' => $hook3->id,
     ])->expectsOutput('Set default webhook to '.$hook3->id.' : Test Webhook Three')
         ->assertExitCode(0);
-    $this->assertFalse($hook1->fresh()->is_default);
-    $this->assertFalse($hook2->fresh()->is_default);
-    $this->assertTrue($hook3->fresh()->is_default);
+    expect($hook1->fresh()->is_default)->toBeFalse();
+    expect($hook2->fresh()->is_default)->toBeFalse();
+    expect($hook3->fresh()->is_default)->toBeTrue();
 });
 
 test('if we dont supply the id we are asked for it', function () {
@@ -125,7 +125,7 @@ test('if we dont supply the id we are asked for it', function () {
     ])->expectsQuestion('Which Webhook?', $hook1->name)
         ->expectsOutput('Set default webhook to '.$hook1->id.' : Test Webhook One')
         ->assertExitCode(0);
-    $this->assertTrue($hook1->fresh()->is_default);
-    $this->assertFalse($hook2->fresh()->is_default);
-    $this->assertFalse($hook3->fresh()->is_default);
+    expect($hook1->fresh()->is_default)->toBeTrue();
+    expect($hook2->fresh()->is_default)->toBeFalse();
+    expect($hook3->fresh()->is_default)->toBeFalse();
 });

--- a/tests/Feature/CliTest.php
+++ b/tests/Feature/CliTest.php
@@ -1,152 +1,131 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Models\Webhook;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-final class CliTest extends TestCase
-{
-    use RefreshDatabase;
+uses(TestCase::class);
+uses(RefreshDatabase::class);
 
-    #[Test]
-    public function there_is_an_artisan_command_to_make_a_new_webhook(): void
-    {
-        $this->artisan('webhook:create', [
-            'name' => 'Test Webhook',
-            'url' => 'https://example.com/webhook/1234',
-        ])->assertExitCode(0);
+test('there is an artisan command to make a new webhook', function () {
+    $this->artisan('webhook:create', [
+        'name' => 'Test Webhook',
+        'url' => 'https://example.com/webhook/1234',
+    ])->assertExitCode(0);
 
-        $this->assertEquals(1, Webhook::count());
-        tap(Webhook::first(), function ($hook) {
-            $this->assertEquals('Test Webhook', $hook->name);
-            $this->assertEquals('https://example.com/webhook/1234', $hook->url);
-            $this->assertNotNull($hook->shortcode);
-            $this->assertFalse($hook->is_default);
-        });
-    }
+    $this->assertEquals(1, Webhook::count());
+    tap(Webhook::first(), function ($hook) {
+        $this->assertEquals('Test Webhook', $hook->name);
+        $this->assertEquals('https://example.com/webhook/1234', $hook->url);
+        $this->assertNotNull($hook->shortcode);
+        $this->assertFalse($hook->is_default);
+    });
+});
 
-    #[Test]
-    public function we_can_optionally_pass_a_flag_to_make_the_new_webhook_the_default(): void
-    {
-        $existingDefault = Webhook::factory()->create(['is_default' => true]);
+test('we can optionally pass a flag to make the new webhook the default', function () {
+    $existingDefault = Webhook::factory()->create(['is_default' => true]);
 
-        $this->artisan('webhook:create', [
-            'name' => 'Test Webhook',
-            'url' => 'https://example.com/webhook/1234',
-            'default' => 'true',
-        ])->assertExitCode(0);
+    $this->artisan('webhook:create', [
+        'name' => 'Test Webhook',
+        'url' => 'https://example.com/webhook/1234',
+        'default' => 'true',
+    ])->assertExitCode(0);
 
-        $this->assertEquals(2, Webhook::count());
-        tap(Webhook::where('name', 'Test Webhook')->first(), function ($hook) {
-            $this->assertEquals('Test Webhook', $hook->name);
-            $this->assertEquals('https://example.com/webhook/1234', $hook->url);
-            $this->assertNotNull($hook->shortcode);
-            $this->assertTrue($hook->is_default);
-        });
-        $this->assertFalse($existingDefault->fresh()->is_default);
-    }
+    $this->assertEquals(2, Webhook::count());
+    tap(Webhook::where('name', 'Test Webhook')->first(), function ($hook) {
+        $this->assertEquals('Test Webhook', $hook->name);
+        $this->assertEquals('https://example.com/webhook/1234', $hook->url);
+        $this->assertNotNull($hook->shortcode);
+        $this->assertTrue($hook->is_default);
+    });
+    $this->assertFalse($existingDefault->fresh()->is_default);
+});
 
-    #[Test]
-    public function if_we_dont_pass_options_we_are_asked_for_input(): void
-    {
-        $this->artisan('webhook:create')
-            ->expectsQuestion('Name?', 'Test Webhook')
-            ->expectsQuestion('URL?', 'https://example.com/webhook/1234')
-            ->assertExitCode(0);
+test('if we dont pass options we are asked for input', function () {
+    $this->artisan('webhook:create')
+        ->expectsQuestion('Name?', 'Test Webhook')
+        ->expectsQuestion('URL?', 'https://example.com/webhook/1234')
+        ->assertExitCode(0);
 
-        $this->assertEquals(1, Webhook::count());
-        tap(Webhook::where('name', 'Test Webhook')->first(), function ($hook) {
-            $this->assertEquals('Test Webhook', $hook->name);
-            $this->assertEquals('https://example.com/webhook/1234', $hook->url);
-            $this->assertNotNull($hook->shortcode);
-            $this->assertFalse($hook->is_default);
-        });
-    }
+    $this->assertEquals(1, Webhook::count());
+    tap(Webhook::where('name', 'Test Webhook')->first(), function ($hook) {
+        $this->assertEquals('Test Webhook', $hook->name);
+        $this->assertEquals('https://example.com/webhook/1234', $hook->url);
+        $this->assertNotNull($hook->shortcode);
+        $this->assertFalse($hook->is_default);
+    });
+});
 
-    #[Test]
-    public function there_is_an_artisan_command_to_list_webhooks(): void
-    {
-        $hook1 = Webhook::factory()->create(['name' => 'Test Webhook One', 'url' => 'https://example.com/webhook/1234']);
-        $hook2 = Webhook::factory()->create(['name' => 'Test Webhook Two', 'url' => 'https://example.com/webhook/5678', 'is_default' => true]);
+test('there is an artisan command to list webhooks', function () {
+    $hook1 = Webhook::factory()->create(['name' => 'Test Webhook One', 'url' => 'https://example.com/webhook/1234']);
+    $hook2 = Webhook::factory()->create(['name' => 'Test Webhook Two', 'url' => 'https://example.com/webhook/5678', 'is_default' => true]);
 
-        $this->artisan('webhook:list')
-            ->expectsTable(
-                ['ID', 'Name', 'Shortcode', 'URL', 'Default?'],
-                [[
-                    $hook1->id,
-                    $hook1->name,
-                    $hook1->shortcode,
-                    $hook1->url,
-                    'No',
-                ], [
-                    $hook2->id,
-                    $hook2->name,
-                    $hook2->shortcode,
-                    $hook2->url,
-                    'Yes',
-                ]]
-            )
-            ->assertExitCode(0);
-    }
+    $this->artisan('webhook:list')
+        ->expectsTable(
+            ['ID', 'Name', 'Shortcode', 'URL', 'Default?'],
+            [[
+                $hook1->id,
+                $hook1->name,
+                $hook1->shortcode,
+                $hook1->url,
+                'No',
+            ], [
+                $hook2->id,
+                $hook2->name,
+                $hook2->shortcode,
+                $hook2->url,
+                'Yes',
+            ]]
+        )
+        ->assertExitCode(0);
+});
 
-    #[Test]
-    public function there_is_an_artisan_command_to_delete_a_webhook(): void
-    {
-        $hook1 = Webhook::factory()->create(['name' => 'Test Webhook One', 'url' => 'https://example.com/webhook/1234']);
-        $hook2 = Webhook::factory()->create(['name' => 'Test Webhook Two', 'url' => 'https://example.com/webhook/5678']);
-        $hook3 = Webhook::factory()->create(['name' => 'Test Webhook Three', 'url' => 'https://example.com/webhook/9012']);
+test('there is an artisan command to delete a webhook', function () {
+    $hook1 = Webhook::factory()->create(['name' => 'Test Webhook One', 'url' => 'https://example.com/webhook/1234']);
+    $hook2 = Webhook::factory()->create(['name' => 'Test Webhook Two', 'url' => 'https://example.com/webhook/5678']);
+    $hook3 = Webhook::factory()->create(['name' => 'Test Webhook Three', 'url' => 'https://example.com/webhook/9012']);
 
-        $this->artisan('webhook:delete', [
-            'id' => $hook2->id,
-        ])->expectsOutput('Deleted webhook '.$hook2->id.' : Test Webhook Two')
-            ->assertExitCode(0);
-    }
+    $this->artisan('webhook:delete', [
+        'id' => $hook2->id,
+    ])->expectsOutput('Deleted webhook '.$hook2->id.' : Test Webhook Two')
+        ->assertExitCode(0);
+});
 
-    #[Test]
-    public function if_we_dont_supply_an_id_we_are_asked_to_choose_one(): void
-    {
-        $hook1 = Webhook::factory()->create(['name' => 'Test Webhook One', 'url' => 'https://example.com/webhook/1234']);
-        $hook2 = Webhook::factory()->create(['name' => 'Test Webhook Two', 'url' => 'https://example.com/webhook/5678']);
-        $hook3 = Webhook::factory()->create(['name' => 'Test Webhook Three', 'url' => 'https://example.com/webhook/9012']);
+test('if we dont supply an id we are asked to choose one', function () {
+    $hook1 = Webhook::factory()->create(['name' => 'Test Webhook One', 'url' => 'https://example.com/webhook/1234']);
+    $hook2 = Webhook::factory()->create(['name' => 'Test Webhook Two', 'url' => 'https://example.com/webhook/5678']);
+    $hook3 = Webhook::factory()->create(['name' => 'Test Webhook Three', 'url' => 'https://example.com/webhook/9012']);
 
-        $this->artisan('webhook:delete', [
-        ])->expectsQuestion('Which Webhook?', $hook2->name)
-            ->expectsOutput('Deleted webhook '.$hook2->id.' : Test Webhook Two')
-            ->assertExitCode(0);
-    }
+    $this->artisan('webhook:delete', [
+    ])->expectsQuestion('Which Webhook?', $hook2->name)
+        ->expectsOutput('Deleted webhook '.$hook2->id.' : Test Webhook Two')
+        ->assertExitCode(0);
+});
 
-    #[Test]
-    public function there_is_an_artisan_command_to_set_the_default_webhook(): void
-    {
-        $hook1 = Webhook::factory()->create(['name' => 'Test Webhook One', 'url' => 'https://example.com/webhook/1234']);
-        $hook2 = Webhook::factory()->create(['name' => 'Test Webhook Two', 'url' => 'https://example.com/webhook/5678', 'is_default' => true]);
-        $hook3 = Webhook::factory()->create(['name' => 'Test Webhook Three', 'url' => 'https://example.com/webhook/9012']);
+test('there is an artisan command to set the default webhook', function () {
+    $hook1 = Webhook::factory()->create(['name' => 'Test Webhook One', 'url' => 'https://example.com/webhook/1234']);
+    $hook2 = Webhook::factory()->create(['name' => 'Test Webhook Two', 'url' => 'https://example.com/webhook/5678', 'is_default' => true]);
+    $hook3 = Webhook::factory()->create(['name' => 'Test Webhook Three', 'url' => 'https://example.com/webhook/9012']);
 
-        $this->artisan('webhook:default', [
-            'id' => $hook3->id,
-        ])->expectsOutput('Set default webhook to '.$hook3->id.' : Test Webhook Three')
-            ->assertExitCode(0);
-        $this->assertFalse($hook1->fresh()->is_default);
-        $this->assertFalse($hook2->fresh()->is_default);
-        $this->assertTrue($hook3->fresh()->is_default);
-    }
+    $this->artisan('webhook:default', [
+        'id' => $hook3->id,
+    ])->expectsOutput('Set default webhook to '.$hook3->id.' : Test Webhook Three')
+        ->assertExitCode(0);
+    $this->assertFalse($hook1->fresh()->is_default);
+    $this->assertFalse($hook2->fresh()->is_default);
+    $this->assertTrue($hook3->fresh()->is_default);
+});
 
-    #[Test]
-    public function if_we_dont_supply_the_id_we_are_asked_for_it(): void
-    {
-        $hook1 = Webhook::factory()->create(['name' => 'Test Webhook One', 'url' => 'https://example.com/webhook/1234']);
-        $hook2 = Webhook::factory()->create(['name' => 'Test Webhook Two', 'url' => 'https://example.com/webhook/5678', 'is_default' => true]);
-        $hook3 = Webhook::factory()->create(['name' => 'Test Webhook Three', 'url' => 'https://example.com/webhook/9012']);
+test('if we dont supply the id we are asked for it', function () {
+    $hook1 = Webhook::factory()->create(['name' => 'Test Webhook One', 'url' => 'https://example.com/webhook/1234']);
+    $hook2 = Webhook::factory()->create(['name' => 'Test Webhook Two', 'url' => 'https://example.com/webhook/5678', 'is_default' => true]);
+    $hook3 = Webhook::factory()->create(['name' => 'Test Webhook Three', 'url' => 'https://example.com/webhook/9012']);
 
-        $this->artisan('webhook:default', [
-        ])->expectsQuestion('Which Webhook?', $hook1->name)
-            ->expectsOutput('Set default webhook to '.$hook1->id.' : Test Webhook One')
-            ->assertExitCode(0);
-        $this->assertTrue($hook1->fresh()->is_default);
-        $this->assertFalse($hook2->fresh()->is_default);
-        $this->assertFalse($hook3->fresh()->is_default);
-    }
-}
+    $this->artisan('webhook:default', [
+    ])->expectsQuestion('Which Webhook?', $hook1->name)
+        ->expectsOutput('Set default webhook to '.$hook1->id.' : Test Webhook One')
+        ->assertExitCode(0);
+    $this->assertTrue($hook1->fresh()->is_default);
+    $this->assertFalse($hook2->fresh()->is_default);
+    $this->assertFalse($hook3->fresh()->is_default);
+});

--- a/tests/Feature/CliTest.php
+++ b/tests/Feature/CliTest.php
@@ -4,8 +4,6 @@ use App\Models\Webhook;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
-uses(TestCase::class);
-uses(RefreshDatabase::class);
 
 test('there is an artisan command to make a new webhook', function () {
     $this->artisan('webhook:create', [

--- a/tests/Feature/UserManagementTest.php
+++ b/tests/Feature/UserManagementTest.php
@@ -127,7 +127,7 @@ test('users cant add the same user twice', function () {
         ->assertSet('error', 'User already exists')
         ->call('createUser');
 
-    $this->assertEquals(1, User::where('username', '=', 'abc1x')->count());
+    expect(User::where('username', '=', 'abc1x')->count())->toEqual(1);
 });
 
 // Helpers

--- a/tests/Feature/UserManagementTest.php
+++ b/tests/Feature/UserManagementTest.php
@@ -9,8 +9,6 @@ use Ohffs\Ldap\LdapConnectionInterface;
 use Ohffs\Ldap\LdapUser;
 use Tests\TestCase;
 
-uses(TestCase::class);
-uses(RefreshDatabase::class);
 
 test('only authenticated users can see the user management page', function () {
     $response = $this->get(route('user.index'));

--- a/tests/Feature/UserManagementTest.php
+++ b/tests/Feature/UserManagementTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Http\Livewire\UserList;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -9,148 +7,134 @@ use Livewire\Livewire;
 use Ohffs\Ldap\FakeLdapConnection;
 use Ohffs\Ldap\LdapConnectionInterface;
 use Ohffs\Ldap\LdapUser;
-use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-final class UserManagementTest extends TestCase
+uses(TestCase::class);
+uses(RefreshDatabase::class);
+
+test('only authenticated users can see the user management page', function () {
+    $response = $this->get(route('user.index'));
+
+    $response->assertRedirect(route('auth.login'));
+});
+
+test('existing users can see the user management page', function () {
+    $user1 = User::factory()->create();
+    $user2 = User::factory()->create();
+
+    $response = $this->actingAs($user1)->get(route('user.index'));
+
+    $response->assertOk();
+    $response->assertSee('User Management');
+    $response->assertSee($user1->username);
+    $response->assertSee($user2->username);
+    $response->assertSeeLivewire('user-list');
+});
+
+test('users can delete an existing user but not themselves', function () {
+    $user1 = User::factory()->create();
+    $user2 = User::factory()->create();
+
+    Livewire::actingAs($user1)
+        ->test(UserList::class)
+        ->assertSee($user1->username)
+        ->assertSee($user2->username)
+        ->call('deleteUser', $user2->id)
+        ->assertSee($user1->username)
+        ->assertDontSee($user2->username)
+        ->call('deleteUser', $user1->id)
+        ->assertSee($user1->username)
+        ->assertDontSee($user2->username);
+});
+
+test('users can add a new ldap user', function () {
+    $user1 = User::factory()->create();
+    $user2 = User::factory()->create();
+    fakeLdapConnection();
+    \Ldap::shouldReceive('findUser')->with('abc1x')->andReturn(new LdapUser([
+        [
+            'uid' => ['abc1x'],
+            'mail' => ['abc1x@example.com'],
+            'sn' => ['smith'],
+            'givenname' => ['jenny'],
+            'telephonenumber' => ['12345'],
+        ],
+    ]));
+
+    Livewire::actingAs($user1)
+        ->test(UserList::class)
+        ->assertSee($user1->username)
+        ->assertSee($user2->username)
+        ->assertDontSee('abc1x@example.com')
+        ->set('username', 'abc1x')
+        ->call('lookupUser')
+        ->assertSet('email', 'abc1x@example.com')
+        ->call('createUser')
+        ->assertSee('abc1x@example.com')
+        ->assertSet('email', '');
+
+    $this->assertDatabaseHas('users', [
+        'username' => 'abc1x',
+        'surname' => 'smith',
+        'forenames' => 'jenny',
+        'email' => 'abc1x@example.com',
+    ]);
+});
+
+test('users cant add a user that doesnt exist in ldap', function () {
+    $user1 = User::factory()->create();
+    $user2 = User::factory()->create();
+    fakeLdapConnection();
+    \Ldap::shouldReceive('findUser')->with('abc1x')->andReturn(false);
+
+    Livewire::actingAs($user1)
+        ->test(UserList::class)
+        ->assertSee($user1->username)
+        ->assertSee($user2->username)
+        ->assertDontSee('abc1x@example.com')
+        ->set('username', 'abc1x')
+        ->call('lookupUser')
+        ->assertSet('email', '')
+        ->assertSet('error', 'User not found')
+        ->call('createUser');
+
+    $this->assertDatabaseMissing('users', [
+        'username' => 'abc1x',
+    ]);
+});
+
+test('users cant add the same user twice', function () {
+    $user1 = User::factory()->create();
+    $user2 = User::factory()->create(['username' => 'abc1x']);
+    fakeLdapConnection();
+    \Ldap::shouldReceive('findUser')->with('abc1x')->andReturn(new LdapUser([
+        [
+            'uid' => ['abc1x'],
+            'mail' => ['abc1x@example.com'],
+            'sn' => ['smith'],
+            'givenname' => ['jenny'],
+            'telephonenumber' => ['12345'],
+        ],
+    ]));
+
+    Livewire::actingAs($user1)
+        ->test(UserList::class)
+        ->assertSee($user1->username)
+        ->assertSee($user2->username)
+        ->set('username', 'abc1x')
+        ->call('lookupUser')
+        ->assertSet('email', '')
+        ->assertSet('error', 'User already exists')
+        ->call('createUser');
+
+    $this->assertEquals(1, User::where('username', '=', 'abc1x')->count());
+});
+
+// Helpers
+function fakeLdapConnection()
 {
-    use RefreshDatabase;
-
-    #[Test]
-    public function only_authenticated_users_can_see_the_user_management_page(): void
-    {
-        $response = $this->get(route('user.index'));
-
-        $response->assertRedirect(route('auth.login'));
-    }
-
-    #[Test]
-    public function existing_users_can_see_the_user_management_page(): void
-    {
-        $user1 = User::factory()->create();
-        $user2 = User::factory()->create();
-
-        $response = $this->actingAs($user1)->get(route('user.index'));
-
-        $response->assertOk();
-        $response->assertSee('User Management');
-        $response->assertSee($user1->username);
-        $response->assertSee($user2->username);
-        $response->assertSeeLivewire('user-list');
-    }
-
-    #[Test]
-    public function users_can_delete_an_existing_user_but_not_themselves(): void
-    {
-        $user1 = User::factory()->create();
-        $user2 = User::factory()->create();
-
-        Livewire::actingAs($user1)
-            ->test(UserList::class)
-            ->assertSee($user1->username)
-            ->assertSee($user2->username)
-            ->call('deleteUser', $user2->id)
-            ->assertSee($user1->username)
-            ->assertDontSee($user2->username)
-            ->call('deleteUser', $user1->id)
-            ->assertSee($user1->username)
-            ->assertDontSee($user2->username);
-    }
-
-    #[Test]
-    public function users_can_add_a_new_ldap_user(): void
-    {
-        $user1 = User::factory()->create();
-        $user2 = User::factory()->create();
-        $this->fakeLdapConnection();
-        \Ldap::shouldReceive('findUser')->with('abc1x')->andReturn(new LdapUser([
-            [
-                'uid' => ['abc1x'],
-                'mail' => ['abc1x@example.com'],
-                'sn' => ['smith'],
-                'givenname' => ['jenny'],
-                'telephonenumber' => ['12345'],
-            ],
-        ]));
-
-        Livewire::actingAs($user1)
-            ->test(UserList::class)
-            ->assertSee($user1->username)
-            ->assertSee($user2->username)
-            ->assertDontSee('abc1x@example.com')
-            ->set('username', 'abc1x')
-            ->call('lookupUser')
-            ->assertSet('email', 'abc1x@example.com')
-            ->call('createUser')
-            ->assertSee('abc1x@example.com')
-            ->assertSet('email', '');
-
-        $this->assertDatabaseHas('users', [
-            'username' => 'abc1x',
-            'surname' => 'smith',
-            'forenames' => 'jenny',
-            'email' => 'abc1x@example.com',
-        ]);
-    }
-
-    #[Test]
-    public function users_cant_add_a_user_that_doesnt_exist_in_ldap(): void
-    {
-        $user1 = User::factory()->create();
-        $user2 = User::factory()->create();
-        $this->fakeLdapConnection();
-        \Ldap::shouldReceive('findUser')->with('abc1x')->andReturn(false);
-
-        Livewire::actingAs($user1)
-            ->test(UserList::class)
-            ->assertSee($user1->username)
-            ->assertSee($user2->username)
-            ->assertDontSee('abc1x@example.com')
-            ->set('username', 'abc1x')
-            ->call('lookupUser')
-            ->assertSet('email', '')
-            ->assertSet('error', 'User not found')
-            ->call('createUser');
-
-        $this->assertDatabaseMissing('users', [
-            'username' => 'abc1x',
-        ]);
-    }
-
-    #[Test]
-    public function users_cant_add_the_same_user_twice(): void
-    {
-        $user1 = User::factory()->create();
-        $user2 = User::factory()->create(['username' => 'abc1x']);
-        $this->fakeLdapConnection();
-        \Ldap::shouldReceive('findUser')->with('abc1x')->andReturn(new LdapUser([
-            [
-                'uid' => ['abc1x'],
-                'mail' => ['abc1x@example.com'],
-                'sn' => ['smith'],
-                'givenname' => ['jenny'],
-                'telephonenumber' => ['12345'],
-            ],
-        ]));
-
-        Livewire::actingAs($user1)
-            ->test(UserList::class)
-            ->assertSee($user1->username)
-            ->assertSee($user2->username)
-            ->set('username', 'abc1x')
-            ->call('lookupUser')
-            ->assertSet('email', '')
-            ->assertSet('error', 'User already exists')
-            ->call('createUser');
-
-        $this->assertEquals(1, User::where('username', '=', 'abc1x')->count());
-    }
-
-    private function fakeLdapConnection()
-    {
-        $this->instance(
-            LdapConnectionInterface::class,
-            new FakeLdapConnection('up', 'whatever')
-        );
-    }
+    test()->instance(
+        LdapConnectionInterface::class,
+        new FakeLdapConnection('up', 'whatever')
+    );
 }

--- a/tests/Feature/UserManagementTest.php
+++ b/tests/Feature/UserManagementTest.php
@@ -2,13 +2,10 @@
 
 use App\Http\Livewire\UserList;
 use App\Models\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Livewire;
 use Ohffs\Ldap\FakeLdapConnection;
 use Ohffs\Ldap\LdapConnectionInterface;
 use Ohffs\Ldap\LdapUser;
-use Tests\TestCase;
-
 
 test('only authenticated users can see the user management page', function () {
     $response = $this->get(route('user.index'));

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,8 @@
 <?php
 
+uses(\Tests\TestCase::class)->in('Feature');
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class)->in('Feature');
+
 /*
 |--------------------------------------------------------------------------
 | Test Case

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Test Case
+|--------------------------------------------------------------------------
+|
+| The closure you provide to your test functions is always bound to a specific PHPUnit test
+| case class. By default, that class is "PHPUnit\Framework\TestCase". Of course, you may
+| need to change it using the "uses()" function to bind a different classes or traits.
+|
+*/
+
+/** @link https://pestphp.com/docs/configuring-tests */
+
+/*
+|--------------------------------------------------------------------------
+| Expectations
+|--------------------------------------------------------------------------
+|
+| When you're writing tests, you often need to check that values meet certain conditions. The
+| "expect()" function gives you access to a set of "expectations" methods that you can use
+| to assert different things. Of course, you may extend the Expectation API at any time.
+|
+*/
+
+/** @link https://pestphp.com/docs/custom-expectations */
+
+/*
+|--------------------------------------------------------------------------
+| Functions
+|--------------------------------------------------------------------------
+|
+| While Pest is very powerful out-of-the-box, you may have some testing code specific to your
+| project that you don't want to repeat in every file. Here you can also expose helpers as
+| global functions to help you to reduce the number of lines of code in your test files.
+|
+*/
+
+/** @link https://pestphp.com/docs/custom-helpers */

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -6,5 +6,5 @@
  * A basic test example.
  */
 test('that true is true', function () {
-    $this->assertTrue(true);
+    expect(true)->toBeTrue();
 });

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -1,16 +1,10 @@
 <?php
 
-namespace Tests\Unit;
 
-use PHPUnit\Framework\TestCase;
 
-final class ExampleTest extends TestCase
-{
-    /**
-     * A basic test example.
-     */
-    public function test_that_true_is_true(): void
-    {
-        $this->assertTrue(true);
-    }
-}
+/**
+ * A basic test example.
+ */
+test('that true is true', function () {
+    $this->assertTrue(true);
+});


### PR DESCRIPTION
This pull request contains changes for migrating your test suite from PHPUnit to [Pest](https://pestphp.com/) automated by the [Pest Converter](https://laravelshift.com/phpunit-to-pest-converter).

**Before merging**, you need to:

- Checkout the `shift-139717` branch
- Review **all** of the comments below for additional changes
- Run `composer update` to install Pest with your dependencies
- Run `vendor/bin/pest` to verify the conversion
